### PR TITLE
Fixes the usage of sdkconfig to switch reset active high/low (EHM-48)

### DIFF
--- a/host/api/include/esp_hosted_config.h
+++ b/host/api/include/esp_hosted_config.h
@@ -331,7 +331,7 @@ enum {
   #define H_RESET_ACTIVE_HIGH                        1
 #endif
 
-#ifdef H_RESET_ACTIVE_HIGH
+#if H_RESET_ACTIVE_HIGH
   #define H_RESET_VAL_ACTIVE                         H_GPIO_HIGH
   #define H_RESET_VAL_INACTIVE                       H_GPIO_LOW
 #else


### PR DESCRIPTION
## Description

Changing "RESET GPIO config" in the menuconfig had no effect. See #44

## Related

Fixes #44 

## Testing

I Tested it by changing the setting in menuconfig and measured if reset active high/low could be switched afterwards.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x ] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
