### PR TITLE
Fix processing of received ESP_HCI_IF

### DIFF
--- a/slave/main/slave_bt.c
+++ b/slave/main/slave_bt.c
@@ -88,12 +88,7 @@ static esp_vhci_host_callback_t vhci_host_cb = {
 
 void process_hci_rx_pkt(uint8_t *payload, uint16_t payload_len)
 {
-	/* VHCI needs one extra byte at the start of payload */
-	/* that is accomodated in esp_payload_header */
 	ESP_HEXLOGV("bt_rx", payload, payload_len);
-
-	payload--;
-	payload_len++;
 
 	if (!esp_vhci_host_check_send_available()) {
 		ESP_LOGD(TAG, "VHCI not available");


### PR DESCRIPTION
Greetings!

We have found that in order for esp-hosted-mcu firmware to work as an HCI controller for our host, we need to get rid of decrementing the payload. We are not using the host code from this repo, but are reasonably sure that our outgoing ESP_HCI_IF packets are well-formed, containing of esp_payload_header followed by H4 HCI packet. The last esp-idf version we've been testing against is https://github.com/espressif/esp-idf/commit/67e5e59de3b12f5695f6aeaa0e6d16e2c2d98f8e