### PR TITLE
Feature: allow SDIO slave reset using callback instead of GPIO

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -489,19 +489,6 @@ ESP32XX_SPI_CLK_FREQ_RANGE_MAX := 40
 		menu "Hosted SDIO Configuration"
 			depends on ESP_HOSTED_SDIO_HOST_INTERFACE
 
-			choice ESP_HOSTED_SDIO_RESET_GPIO_CONFIG
-				bool "RESET GPIO Config"
-				default ESP_HOSTED_SDIO_RESET_ACTIVE_HIGH
-				help
-					"If Active High, High->Low->High will trigger reset (Low will trigger reset)
-					 If Active Low, Low->High->Low will trigger reset (High will trigger reset)"
-
-				config ESP_HOSTED_SDIO_RESET_ACTIVE_HIGH
-					bool "RESET: Active High"
-				config ESP_HOSTED_SDIO_RESET_ACTIVE_LOW
-					bool "RESET: Active Low"
-			endchoice
-
 			choice ESP_HOSTED_SDIO_RX_OPTIMIZATION
 				bool "SDIO Receive Optimization"
 				default ESP_HOSTED_SDIO_OPTIMIZATION_RX_STREAMING_MODE
@@ -851,7 +838,29 @@ ESP32XX_SDIO_CLK_FREQ_KHZ_RANGE_MAX := 50000
 						D1 GPIO pin for SDIO. Range enforced dynamically based on slave target to ensure IOMUX compliance.
 			endif
 
+			config ESP_HOSTED_SDIO_RESET_SLAVE_USING_CALLBACK
+				bool "Reset slave using callback function"
+				help
+					Select this option if you want to reset the slave device using a callback function instead of using a GPIO pin.
+					This is useful if the reset line of the slave device is not connected to a GPIO pin of the host device.
+					The callback function should be defined as esp_err_t hosted_sdio_reset_slave_callback(void); in user code.
+
+			choice ESP_HOSTED_SDIO_RESET_GPIO_CONFIG
+				depends on !ESP_HOSTED_SDIO_RESET_SLAVE_USING_CALLBACK
+				bool "RESET GPIO Config"
+				default ESP_HOSTED_SDIO_RESET_ACTIVE_HIGH
+				help
+					"If Active High, High->Low->High will trigger reset (Low will trigger reset)
+					 If Active Low, Low->High->Low will trigger reset (High will trigger reset)"
+
+				config ESP_HOSTED_SDIO_RESET_ACTIVE_HIGH
+					bool "RESET: Active High"
+				config ESP_HOSTED_SDIO_RESET_ACTIVE_LOW
+					bool "RESET: Active Low"
+			endchoice
+
 			config ESP_HOSTED_SDIO_GPIO_RESET_SLAVE
+				depends on !ESP_HOSTED_SDIO_RESET_SLAVE_USING_CALLBACK
 				int "GPIO pin for Reseting slave ESP"
 				default 54 if IDF_TARGET_ESP32P4
 				default 42 if IDF_TARGET_ESP32S3

--- a/host/api/src/esp_hosted_transport_config.c
+++ b/host/api/src/esp_hosted_transport_config.c
@@ -85,7 +85,11 @@ esp_hosted_transport_err_t esp_hosted_transport_get_reset_config(gpio_pin_t *pin
 	default:
 		// transport config not yet initialised. Use default Reset pin config
 		pin_config->port = H_GPIO_PORT_RESET;
+#ifndef CONFIG_ESP_HOSTED_SDIO_RESET_SLAVE_USING_CALLBACK
 		pin_config->pin  = H_GPIO_PIN_RESET;
+#else
+		pin_config->pin  = -1;
+#endif
 		break;
 	}
 

--- a/host/port/esp/freertos/src/port_esp_hosted_host_sdio.c
+++ b/host/port/esp/freertos/src/port_esp_hosted_host_sdio.c
@@ -402,16 +402,29 @@ int hosted_sdio_card_init(void *ctx)
 			sdio_config->bus_width==4? 4:1,
 			config.max_freq_khz);
 	if (sdio_config->bus_width == 4) {
+#ifndef CONFIG_ESP_HOSTED_SDIO_RESET_SLAVE_CALLBACK_FUNCTION
 		ESP_LOGI(TAG, "GPIOs: CLK[%u] CMD[%u] D0[%u] D1[%u] D2[%u] D3[%u] Slave_Reset[%u]",
 				sdio_config->pin_clk.pin, sdio_config->pin_cmd.pin,
 				sdio_config->pin_d0.pin, sdio_config->pin_d1.pin,
 				sdio_config->pin_d2.pin, sdio_config->pin_d3.pin,
 				sdio_config->pin_reset.pin);
+#else
+		ESP_LOGI(TAG, "GPIOs: CLK[%u] CMD[%u] D0[%u] D1[%u] D2[%u] D3[%u]",
+				sdio_config->pin_clk.pin, sdio_config->pin_cmd.pin,
+				sdio_config->pin_d0.pin, sdio_config->pin_d1.pin,
+				sdio_config->pin_d2.pin, sdio_config->pin_d3.pin);
+#endif
 	} else {
+#ifndef CONFIG_ESP_HOSTED_SDIO_RESET_SLAVE_CALLBACK_FUNCTION
 		ESP_LOGI(TAG, "GPIOs: CLK[%u] CMD[%u] D0[%u] D1[%u] Slave_Reset[%u]",
 				sdio_config->pin_clk.pin, sdio_config->pin_cmd.pin,
 				sdio_config->pin_d0.pin, sdio_config->pin_d1.pin,
 				sdio_config->pin_reset.pin);
+#else
+		ESP_LOGI(TAG, "GPIOs: CLK[%u] CMD[%u] D0[%u] D1[%u]",
+				sdio_config->pin_clk.pin, sdio_config->pin_cmd.pin,
+				sdio_config->pin_d0.pin, sdio_config->pin_d1.pin);
+#endif
 	}
 	ESP_LOGI(TAG, "Queues: Tx[%u] Rx[%u] SDIO-Rx-Mode[%u]",
 			sdio_config->tx_queue_size, sdio_config->rx_queue_size,

--- a/host/port/esp/freertos/src/port_esp_hosted_host_transport_defaults.c
+++ b/host/port/esp/freertos/src/port_esp_hosted_host_transport_defaults.c
@@ -20,7 +20,11 @@ struct esp_hosted_sdio_config esp_hosted_get_default_sdio_config(void)
         .pin_d1  = {.port = H_SDIO_PORT_D1,  .pin = H_SDIO_PIN_D1},
         .pin_d2  = {.port = H_SDIO_PORT_D2,  .pin = H_SDIO_PIN_D2},
         .pin_d3  = {.port = H_SDIO_PORT_D3,  .pin = H_SDIO_PIN_D3},
+#ifndef CONFIG_ESP_HOSTED_SDIO_RESET_SLAVE_USING_CALLBACK
         .pin_reset = {.port = H_GPIO_PORT_RESET, .pin = H_GPIO_PIN_RESET},
+#else
+        .pin_reset = {.port = NULL, .pin = -1},
+#endif
         .rx_mode = H_SDIO_HOST_RX_MODE,
         .block_mode = H_SDIO_TX_BLOCK_ONLY_XFER && H_SDIO_RX_BLOCK_ONLY_XFER,
         .iomux_enable = false,


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

Adds a kconfig option for resetting the SDIO slave using a callback function instead of a GPIO.

This change is needed because on my product the reset line of the ESP32-C6 slave is not directly connected to the ESP32-P4.

This PR adds support for optionally defining a function in user code to replace the reset action normally executed using a GPIO pin, allowing for a custom reset procedure. In our case we send a command to an I2C device in order to reset the ESP32-C6 radio.

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

Tested on our hardware using an ESP32-C6 as SDIO slave device.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
