### PR TITLE
fix(host): Fix const qualifier violations for CI builds (EHM-164)

### DIFF
--- a/host/drivers/mempool/mempool.c
+++ b/host/drivers/mempool/mempool.c
@@ -11,7 +11,7 @@
 
 #define MEMPOOL_DEBUG 1
 
-static char * MEM_TAG = "mpool";
+static const char * MEM_TAG = "mpool";
 #if H_MEM_STATS
 #include "esp_log.h"
 #endif

--- a/host/drivers/virtual_serial_if/serial_if.c
+++ b/host/drivers/virtual_serial_if/serial_if.c
@@ -36,7 +36,7 @@ struct serial_drv_handle_t* serial_handle = NULL;
 
 uint16_t compose_tlv(uint8_t* buf, uint8_t* data, uint16_t data_length)
 {
-	char* ep_name = RPC_EP_NAME_RSP;
+	const char* ep_name = RPC_EP_NAME_RSP;
 	uint16_t ep_length = strlen(ep_name);
 	uint16_t count = 0;
 	uint8_t idx;
@@ -66,8 +66,8 @@ uint16_t compose_tlv(uint8_t* buf, uint8_t* data, uint16_t data_length)
 
 uint8_t parse_tlv(uint8_t* data, uint32_t* pro_len)
 {
-	char* ep_name = RPC_EP_NAME_RSP;
-	char* ep_name2 = RPC_EP_NAME_EVT;
+	const char* ep_name = RPC_EP_NAME_RSP;
+	const char* ep_name2 = RPC_EP_NAME_EVT;
 	uint64_t len = 0;
 	uint16_t val_len = 0;
 	if (data[len] == PROTO_PSER_TLV_T_EPNAME) {
@@ -158,7 +158,7 @@ int transport_pserial_open(void)
 
 int transport_pserial_send(uint8_t* data, uint16_t data_length)
 {
-	char* ep_name = RPC_EP_NAME_RSP;
+	const char* ep_name = RPC_EP_NAME_RSP;
 	int count = 0, ret = 0;
 	uint16_t buf_len = 0;
 	uint8_t *write_buf = NULL;

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.10.0"
+version: "2.10.1"
 description: ESP-Hosted-MCU provide drivers to act any ESP chipset as Wi-Fi or Bluetooth co-processor.
 url: https://github.com/espressif/esp-hosted-mcu
 examples:


### PR DESCRIPTION
## Description
ESP-IDF MR 45069 enables -Wwrite-strings and -Werror=discarded-qualifiers in CI builds. This PR fixes const qualifier violations in examples that use `espressif/esp_hosted` managed component causing build failures.

## Related
- https://github.com/espressif/esp-idf/issues/18120

## Testing

- Tested ESP-IDF build locally