### PR TITLE
Feature: add option for restarting radio using callback function instead of GPIO (EHM-196)

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -257,6 +257,14 @@ menu "ESP-Hosted config"
 
 		menu "Host SPI GPIOs Config"
 
+			config ESP_HOSTED_SPI_RESET_SLAVE_USING_CALLBACK
+				bool "Reset slave using callback function"
+				default n
+				help
+					Select this option if you want to reset the slave device using a callback function instead of using a GPIO pin.
+					This is useful if the reset line of the slave device is not connected to a GPIO pin of the host device.
+					The callback function should be defined as int hosted_reset_slave_callback(void); in user code.
+
 			choice ESP_HOSTED_SPI_HANDSHAKE_GPIO_CONFIG
 				bool "Handshake GPIO Config"
 				default ESP_HOSTED_HS_ACTIVE_HIGH
@@ -278,6 +286,7 @@ menu "ESP-Hosted config"
 			endchoice
 
 			choice ESP_HOSTED_SPI_RESET_GPIO_CONFIG
+				depends on !ESP_HOSTED_SPI_RESET_SLAVE_USING_CALLBACK
 				bool "Reset GPIO Config"
 				default ESP_HOSTED_SPI_RESET_ACTIVE_HIGH
 				help
@@ -563,6 +572,7 @@ menu "ESP-Hosted config"
 				default 100
 
 			config ESP_HOSTED_SPI_GPIO_RESET_SLAVE
+				depends on !ESP_HOSTED_SPI_RESET_SLAVE_USING_CALLBACK
 				int "GPIO pin for Resetting slave ESP"
 				default 54 if ESP_HOSTED_P4_C5_CORE_BOARD || ESP_HOSTED_P4_C6_CORE_BOARD || ESP_HOSTED_P4_C61_CORE_BOARD
 				default 9 if ESP32P4_EYE_C6_BOARD
@@ -640,7 +650,16 @@ ESP32XX_SPI_CLK_FREQ_RANGE_MAX := 40
 		menu "Hosted SDIO Configuration"
 			depends on ESP_HOSTED_SDIO_HOST_INTERFACE
 
+			config ESP_HOSTED_SDIO_RESET_SLAVE_USING_CALLBACK
+				bool "Reset slave using callback function"
+				default n
+				help
+					Select this option if you want to reset the slave device using a callback function instead of using a GPIO pin.
+					This is useful if the reset line of the slave device is not connected to a GPIO pin of the host device.
+					The callback function should be defined as int hosted_reset_slave_callback(void); in user code.
+
 			choice ESP_HOSTED_SDIO_RESET_GPIO_CONFIG
+				depends on !ESP_HOSTED_SDIO_RESET_SLAVE_USING_CALLBACK
 				bool "RESET GPIO Config"
 				default ESP_HOSTED_SDIO_RESET_ACTIVE_HIGH
 				help
@@ -1048,6 +1067,7 @@ ESP32XX_SDIO_CLK_FREQ_KHZ_RANGE_MAX := 50000
 			endif
 
 			config ESP_HOSTED_SDIO_GPIO_RESET_SLAVE
+				depends on !ESP_HOSTED_SDIO_RESET_SLAVE_USING_CALLBACK
 				int "GPIO pin for Resetting slave ESP"
 				default 9 if ESP32P4_EYE_C6_BOARD
 				default 54 if IDF_TARGET_ESP32P4
@@ -1156,7 +1176,16 @@ ESP32XX_SDIO_CLK_FREQ_KHZ_RANGE_MAX := 50000
 			default 4 if ESP_HOSTED_SPI_HD_PRIV_INTERFACE_4_DATA_LINES
 			default 2 if ESP_HOSTED_SPI_HD_PRIV_INTERFACE_2_DATA_LINES
 
+		config ESP_HOSTED_SPI_HD_RESET_SLAVE_USING_CALLBACK
+			bool "Reset slave using callback function"
+			default n
+			help
+				Select this option if you want to reset the slave device using a callback function instead of using a GPIO pin.
+				This is useful if the reset line of the slave device is not connected to a GPIO pin of the host device.
+				The callback function should be defined as int hosted_reset_slave_callback(void); in user code.
+
 		choice ESP_HOSTED_SPI_HD_RESET_GPIO_CONFIG
+			depends on !ESP_HOSTED_SPI_HD_RESET_SLAVE_USING_CALLBACK
 			bool "RESET GPIO Config"
 			default ESP_HOSTED_SPI_HD_RESET_ACTIVE_HIGH
 			help
@@ -1432,6 +1461,7 @@ ESP32XX_SDIO_CLK_FREQ_KHZ_RANGE_MAX := 50000
 				default 100
 
 			config ESP_HOSTED_SPI_HD_GPIO_RESET_SLAVE
+				depends on !ESP_HOSTED_SPI_HD_RESET_SLAVE_USING_CALLBACK
 				int "GPIO pin for Resetting slave ESP"
 				default 54 if ESP_HOSTED_P4_C5_CORE_BOARD || ESP_HOSTED_P4_C6_CORE_BOARD || ESP_HOSTED_P4_C61_CORE_BOARD
 				default 9 if ESP32P4_EYE_C6_BOARD
@@ -1495,7 +1525,16 @@ ESP32XX_SPI_HD_CLK_FREQ_RANGE_MAX := 40
 	menu "UART Configuration"
 		depends on ESP_HOSTED_UART_HOST_INTERFACE
 
+		config ESP_HOSTED_UART_RESET_SLAVE_USING_CALLBACK
+			bool "Reset slave using callback function"
+			default n
+			help
+				Select this option if you want to reset the slave device using a callback function instead of using a GPIO pin.
+				This is useful if the reset line of the slave device is not connected to a GPIO pin of the host device.
+				The callback function should be defined as int hosted_reset_slave_callback(void); in user code.
+
 		choice ESP_HOSTED_UART_RESET_GPIO_CONFIG
+			depends on !ESP_HOSTED_UART_RESET_SLAVE_USING_CALLBACK
 			bool "RESET GPIO Config"
 			default ESP_HOSTED_UART_RESET_ACTIVE_HIGH
 			help
@@ -1637,6 +1676,7 @@ ESP32XX_SPI_HD_CLK_FREQ_RANGE_MAX := 40
 			default 2 if ESP_HOSTED_UART_PRIV_STOP_BITS_2
 
 		config ESP_HOSTED_UART_GPIO_RESET_SLAVE
+			depends on !ESP_HOSTED_UART_RESET_SLAVE_USING_CALLBACK
 			int "GPIO pin for Resetting slave ESP"
 			default 54 if ESP_HOSTED_P4_C5_CORE_BOARD || ESP_HOSTED_P4_C6_CORE_BOARD || ESP_HOSTED_P4_C61_CORE_BOARD
 			default 9 if ESP32P4_EYE_C6_BOARD
@@ -1721,6 +1761,11 @@ ESP32XX_SPI_HD_CLK_FREQ_RANGE_MAX := 40
 			bool
 			default n if ESP_HOSTED_SDIO_RESET_ACTIVE_HIGH || ESP_HOSTED_SPI_RESET_ACTIVE_HIGH || ESP_HOSTED_SPI_HD_RESET_ACTIVE_HIGH || ESP_HOSTED_UART_RESET_ACTIVE_HIGH
 			default y if ESP_HOSTED_SDIO_RESET_ACTIVE_LOW || ESP_HOSTED_SPI_RESET_ACTIVE_LOW || ESP_HOSTED_SPI_HD_RESET_ACTIVE_LOW || ESP_HOSTED_UART_RESET_ACTIVE_LOW
+
+	config ESP_HOSTED_RESET_SLAVE_USING_CALLBACK
+			bool
+			default n if !ESP_HOSTED_SPI_RESET_SLAVE_USING_CALLBACK && !ESP_HOSTED_SDIO_RESET_SLAVE_USING_CALLBACK && !ESP_HOSTED_SPI_HD_RESET_SLAVE_USING_CALLBACK && !ESP_HOSTED_UART_RESET_SLAVE_USING_CALLBACK
+			default y if ESP_HOSTED_SPI_RESET_SLAVE_USING_CALLBACK || ESP_HOSTED_SDIO_RESET_SLAVE_USING_CALLBACK || ESP_HOSTED_SPI_HD_RESET_SLAVE_USING_CALLBACK || ESP_HOSTED_UART_RESET_SLAVE_USING_CALLBACK
 
 	menu "Bluetooth Support"
 

--- a/host/drivers/power_save/power_save_drv.c
+++ b/host/drivers/power_save/power_save_drv.c
@@ -195,6 +195,7 @@ static int notify_slave_host_power_save_stop(void)
 int hold_slave_reset_gpio_pre_power_save(void)
 {
 #if H_HOST_PS_ALLOWED
+#ifndef CONFIG_ESP_HOSTED_RESET_SLAVE_USING_CALLBACK
 	gpio_pin_t reset_pin = { .port = H_GPIO_PORT_RESET, .pin = H_GPIO_PIN_RESET };
 
 	if (ESP_TRANSPORT_OK != esp_hosted_transport_get_reset_config(&reset_pin)) {
@@ -209,12 +210,14 @@ int hold_slave_reset_gpio_pre_power_save(void)
 
 	return g_h.funcs->_h_hold_gpio(reset_pin.port, reset_pin.pin, H_ENABLE);
 #endif
+#endif
 	return 0;
 }
 
 int release_slave_reset_gpio_post_wakeup(void)
 {
 #if H_HOST_PS_ALLOWED
+#ifndef CONFIG_ESP_HOSTED_RESET_SLAVE_USING_CALLBACK
 	gpio_pin_t reset_pin = { .port = H_GPIO_PORT_RESET, .pin = H_GPIO_PIN_RESET };
 
 	if (ESP_TRANSPORT_OK != esp_hosted_transport_get_reset_config(&reset_pin)) {
@@ -228,6 +231,7 @@ int release_slave_reset_gpio_post_wakeup(void)
 	}
 
 	return g_h.funcs->_h_hold_gpio(reset_pin.port, reset_pin.pin, H_DISABLE);
+#endif
 #endif
 	return 0;
 }

--- a/host/drivers/transport/sdio/sdio_drv.c
+++ b/host/drivers/transport/sdio/sdio_drv.c
@@ -1509,14 +1509,9 @@ static esp_err_t transport_card_init(void *bus_handle, uint32_t timeout_ms)
 	return res;
 }
 
-static esp_err_t transport_gpio_reset(void *bus_handle, gpio_pin_t reset_pin)
+static esp_err_t transport_gpio_reset(void)
 {
-	g_h.funcs->_h_config_gpio(reset_pin.port, reset_pin.pin, H_GPIO_MODE_DEF_OUTPUT);
-	g_h.funcs->_h_write_gpio(reset_pin.port, reset_pin.pin, H_RESET_VAL_ACTIVE);
-	g_h.funcs->_h_msleep(10);
-	g_h.funcs->_h_write_gpio(reset_pin.port, reset_pin.pin, H_RESET_VAL_INACTIVE);
-	g_h.funcs->_h_msleep(10);
-	g_h.funcs->_h_write_gpio(reset_pin.port, reset_pin.pin, H_RESET_VAL_ACTIVE);
+	g_h.funcs->_h_restart_slave();
 	g_h.funcs->_h_msleep(H_HOST_SDIO_RESET_DELAY_MS);
 	return ESP_OK;
 }
@@ -1526,14 +1521,6 @@ static esp_err_t transport_gpio_reset(void *bus_handle, gpio_pin_t reset_pin)
 int ensure_slave_bus_ready(void *bus_handle)
 {
 	int res = -1;
-	gpio_pin_t reset_pin = { .port = H_GPIO_PORT_RESET, .pin = H_GPIO_PIN_RESET };
-
-	if (ESP_TRANSPORT_OK != esp_hosted_transport_get_reset_config(&reset_pin)) {
-		ESP_LOGE(TAG, "Unable to get RESET config for transport");
-		return -1;
-	}
-
-	assert(reset_pin.pin != -1);
 
 	release_slave_reset_gpio_post_wakeup();
 
@@ -1552,7 +1539,7 @@ int ensure_slave_bus_ready(void *bus_handle)
 		/* Give a chance to reset and recover the slave */
 		if (res) {
 			ESP_LOGI(TAG, "Attempt slave reset");
-			transport_gpio_reset(bus_handle, reset_pin);
+			transport_gpio_reset();
 		}
 
 		res = transport_card_init(bus_handle, CARD_INIT_TIMEOUT_MS);
@@ -1588,8 +1575,8 @@ int ensure_slave_bus_ready(void *bus_handle)
 		}
 	} else {
 		/* Always reset slave on host boot up */
-		ESP_LOGW(TAG, "Reset slave using GPIO[%u]", reset_pin.pin);
-		transport_gpio_reset(bus_handle, reset_pin);
+		ESP_LOGW(TAG, "Reset slave");
+		transport_gpio_reset();
 
 		res = transport_card_init(bus_handle, CARD_INIT_TIMEOUT_MS);
 		if (res) {

--- a/host/drivers/transport/spi/spi_drv.c
+++ b/host/drivers/transport/spi/spi_drv.c
@@ -860,15 +860,10 @@ void check_if_max_freq_used(uint8_t chip_type)
 		break;
 	}
 }
-static esp_err_t transport_gpio_reset(void *bus_handle, gpio_pin_t reset_pin)
+static esp_err_t transport_gpio_reset(void)
 {
-	ESP_LOGI(TAG, "Resetting slave on SPI bus with pin %d", reset_pin.pin);
-	g_h.funcs->_h_config_gpio(reset_pin.port, reset_pin.pin, H_GPIO_MODE_DEF_OUTPUT);
-	g_h.funcs->_h_write_gpio(reset_pin.port, reset_pin.pin, H_RESET_VAL_ACTIVE);
-	g_h.funcs->_h_msleep(10);
-	g_h.funcs->_h_write_gpio(reset_pin.port, reset_pin.pin, H_RESET_VAL_INACTIVE);
-	g_h.funcs->_h_msleep(10);
-	g_h.funcs->_h_write_gpio(reset_pin.port, reset_pin.pin, H_RESET_VAL_ACTIVE);
+	ESP_LOGI(TAG, "Resetting slave on SPI bus");
+	g_h.funcs->_h_restart_slave();
 	/* Delay for a short while to allow co-processor to take control
 	 * of GPIO signals after reset. Otherwise, we may false detect on
 	 * the GPIOs going high during the reset.
@@ -880,14 +875,6 @@ static esp_err_t transport_gpio_reset(void *bus_handle, gpio_pin_t reset_pin)
 int ensure_slave_bus_ready(void *bus_handle)
 {
 	esp_err_t res = ESP_OK;
-	gpio_pin_t reset_pin = { .port = H_GPIO_PORT_RESET, .pin = H_GPIO_PIN_RESET };
-
-	if (ESP_TRANSPORT_OK != esp_hosted_transport_get_reset_config(&reset_pin)) {
-		ESP_LOGE(TAG, "Unable to get RESET config for transport");
-		return ESP_FAIL;
-	}
-
-	assert(reset_pin.pin != -1);
 
 	release_slave_reset_gpio_post_wakeup();
 
@@ -895,7 +882,7 @@ int ensure_slave_bus_ready(void *bus_handle)
 		stop_host_power_save();
 	} else {
 		ESP_LOGI(TAG, "Resetting slave");
-		transport_gpio_reset(bus_handle, reset_pin);
+		transport_gpio_reset();
 	}
 
 	return res;

--- a/host/drivers/transport/spi_hd/spi_hd_drv.c
+++ b/host/drivers/transport/spi_hd/spi_hd_drv.c
@@ -895,26 +895,13 @@ void check_if_max_freq_used(uint8_t chip_type)
 int ensure_slave_bus_ready(void *bus_handle)
 {
 	esp_err_t res = ESP_OK;
-	gpio_pin_t reset_pin = { .port = H_GPIO_PORT_RESET, .pin = H_GPIO_PIN_RESET };
-
-	if (ESP_TRANSPORT_OK != esp_hosted_transport_get_reset_config(&reset_pin)) {
-		ESP_LOGE(TAG, "Unable to get RESET config for transport");
-		return ESP_FAIL;
-	}
-
-	assert(reset_pin.pin != -1);
 
 	release_slave_reset_gpio_post_wakeup();
 
 	if (!esp_hosted_woke_from_power_save()) {
 		/* Reset the slave */
-		ESP_LOGI(TAG, "Resetting slave on SPI HD bus with pin %d", reset_pin.pin);
-		g_h.funcs->_h_config_gpio(reset_pin.port, reset_pin.pin, H_GPIO_MODE_DEF_OUTPUT);
-		g_h.funcs->_h_write_gpio(reset_pin.port, reset_pin.pin, H_RESET_VAL_ACTIVE);
-		g_h.funcs->_h_msleep(10);
-		g_h.funcs->_h_write_gpio(reset_pin.port, reset_pin.pin, H_RESET_VAL_INACTIVE);
-		g_h.funcs->_h_msleep(10);
-		g_h.funcs->_h_write_gpio(reset_pin.port, reset_pin.pin, H_RESET_VAL_ACTIVE);
+		ESP_LOGI(TAG, "Resetting slave on SPI HD bus");
+		g_h.funcs->_h_restart_slave();
 	} else {
 		stop_host_power_save();
 	}

--- a/host/drivers/transport/uart/uart_drv.c
+++ b/host/drivers/transport/uart/uart_drv.c
@@ -660,26 +660,13 @@ void bus_deinit_internal(void *bus_handle)
 int ensure_slave_bus_ready(void *bus_handle)
 {
 	esp_err_t res = ESP_OK;
-	gpio_pin_t reset_pin = { .port = H_GPIO_PORT_RESET, .pin = H_GPIO_PIN_RESET };
-
-	if (ESP_TRANSPORT_OK != esp_hosted_transport_get_reset_config(&reset_pin)) {
-		ESP_LOGE(TAG, "Unable to get RESET config for transport");
-		return ESP_FAIL;
-	}
-
-	assert(reset_pin.pin != -1);
 
 	release_slave_reset_gpio_post_wakeup();
 
 	if (!esp_hosted_woke_from_power_save()) {
 		/* Reset the slave */
-		ESP_LOGI(TAG, "Resetting slave on UART bus with pin %d", reset_pin.pin);
-		g_h.funcs->_h_config_gpio(reset_pin.port, reset_pin.pin, H_GPIO_MODE_DEF_OUTPUT);
-		g_h.funcs->_h_write_gpio(reset_pin.port, reset_pin.pin, H_RESET_VAL_ACTIVE);
-		g_h.funcs->_h_msleep(10);
-		g_h.funcs->_h_write_gpio(reset_pin.port, reset_pin.pin, H_RESET_VAL_INACTIVE);
-		g_h.funcs->_h_msleep(10);
-		g_h.funcs->_h_write_gpio(reset_pin.port, reset_pin.pin, H_RESET_VAL_ACTIVE);
+		ESP_LOGI(TAG, "Resetting slave on UART bus");
+		g_h.funcs->_h_restart_slave();
 		// flush input
 		if (uart_handle) {
 			g_h.funcs->_h_uart_flush_input(uart_handle);

--- a/host/esp_hosted_os_abstraction.h
+++ b/host/esp_hosted_os_abstraction.h
@@ -121,6 +121,8 @@ typedef struct {
 /* 64 */ int (*_h_config_host_power_save_hal_impl)(uint32_t power_save_type, void* gpio_port, uint32_t gpio_num, int level);
 /* 65 */ int (*_h_start_host_power_save_hal_impl)(uint32_t power_save_type);
 /* 66 */ int (*_h_event_post)(esp_event_base_t event_base, int32_t event_id, void* event_data, size_t event_data_size, uint32_t ticks_to_wait);
+
+/* 67 */ int (*_h_restart_slave)(void);
 } hosted_osi_funcs_t;
 
 struct hosted_config_t {

--- a/host/port/esp/freertos/include/port_esp_hosted_host_config.h
+++ b/host/port/esp/freertos/include/port_esp_hosted_host_config.h
@@ -397,7 +397,11 @@ enum {
 #endif
 
 /* Generic reset pin config */
+#ifdef CONFIG_ESP_HOSTED_RESET_SLAVE_USING_CALLBACK
+#define H_GPIO_PIN_RESET                             -1
+#else
 #define H_GPIO_PIN_RESET                             CONFIG_ESP_HOSTED_GPIO_SLAVE_RESET_SLAVE
+#endif
 #define H_GPIO_PORT_RESET                            NULL
 
 /* If Reset pin is Enable, it is Active High.

--- a/host/port/esp/freertos/src/port_esp_hosted_host_os.c
+++ b/host/port/esp/freertos/src/port_esp_hosted_host_os.c
@@ -834,6 +834,22 @@ int hosted_event_post(esp_event_base_t event_base, int32_t event_id,
 	return esp_event_post(event_base, event_id, event_data, event_data_size, ticks_to_wait);
 }
 
+int hosted_restart_slave(void)
+{
+#ifndef CONFIG_ESP_HOSTED_RESET_SLAVE_USING_CALLBACK
+	hosted_config_gpio(H_GPIO_PORT_RESET, H_GPIO_PIN_RESET, H_GPIO_MODE_DEF_OUTPUT);
+	hosted_write_gpio(H_GPIO_PORT_RESET, H_GPIO_PIN_RESET, H_RESET_VAL_ACTIVE);
+	hosted_msleep(10);
+	hosted_write_gpio(H_GPIO_PORT_RESET, H_GPIO_PIN_RESET, H_RESET_VAL_INACTIVE);
+	hosted_msleep(10);
+	hosted_write_gpio(H_GPIO_PORT_RESET, H_GPIO_PIN_RESET, H_RESET_VAL_ACTIVE);
+	return 0;
+#else
+	extern int hosted_reset_slave_callback(void);
+	return hosted_reset_slave_callback();
+#endif
+}
+
 void hosted_log_write(int  level,
 					const char *tag,
 					const char *format, ...)
@@ -1002,4 +1018,5 @@ hosted_osi_funcs_t g_hosted_osi_funcs = {
 	._h_config_host_power_save_hal_impl = hosted_config_host_power_save,
 	._h_start_host_power_save_hal_impl = hosted_start_host_power_save,
 	._h_event_post               =  hosted_event_post              ,
+	._h_restart_slave            =  hosted_restart_slave           ,
 };


### PR DESCRIPTION
## Description

This PR adds support for defining a user controlled reset function outside of the ESP-HOSTED scope, to be used instead of reset using GPIO.

I need this feature because on my product the radio reset pin is not directly controlled using a GPIO on the ESP32-P4 but instead via an I2C connected device, the callback function allows me to reset the radio using this alternative method.

## Related

This is a re-implementation of the feature introduced earlier in this PR: https://github.com/espressif/esp-hosted-mcu/pull/101

## Testing

Tested by enabling the new menuconfig option and defining a callback function.

