### PR TITLE
fix: guard CONFIG_ESP_SPI_HD_GPIO_D2/D3 behind 4-line mode check (EHM-205)

### DIFF
--- a/slave/main/slave_transport_gpio_pin_guard.c
+++ b/slave/main/slave_transport_gpio_pin_guard.c
@@ -53,8 +53,10 @@ static uint64_t get_reserved_pin_mask(void)
 	add_pin(&mask, CONFIG_ESP_SPI_HD_GPIO_CLK);
 	add_pin(&mask, CONFIG_ESP_SPI_HD_GPIO_D0);
 	add_pin(&mask, CONFIG_ESP_SPI_HD_GPIO_D1);
+#ifdef CONFIG_ESP_SPI_HD_PRIV_INTERFACE_4_DATA_LINES
 	add_pin(&mask, CONFIG_ESP_SPI_HD_GPIO_D2);
 	add_pin(&mask, CONFIG_ESP_SPI_HD_GPIO_D3);
+#endif
 	add_pin(&mask, CONFIG_ESP_SPI_HD_GPIO_DATA_READY);
 	add_pin(&mask, CONFIG_ESP_SPI_HD_GPIO_RESET);
 #endif


### PR DESCRIPTION
## Summary
  `slave_transport_gpio_pin_guard.c` unconditionally references `CONFIG_ESP_SPI_HD_GPIO_D2` and
  `CONFIG_ESP_SPI_HD_GPIO_D3` inside the `CONFIG_ESP_SPI_HD_HOST_INTERFACE` block. These macros are only defined when
  4-line SPI half-duplex mode is selected, causing a build failure when 2-line mode is chosen with the error:
  "CONFIG_ESP_SPI_HD_GPIO_D2/D3 undeclared (first use in this function)".

  ## Fix
  Wrap the D2/D3 `add_pin()` calls behind `#ifdef CONFIG_ESP_SPI_HD_PRIV_INTERFACE_4_DATA_LINES`. This is consistent
  with the same guard already used in `spi_hd_slave_api.c` lines 38-41.

  ## Related
  - Same guard pattern: `spi_hd_slave_api.c:38-41` already uses `#if (NUM_DATA_BITS == 4)` to guard `GPIO_D2`/`GPIO_D3`
  definitions

  ## Testing
  - Build with 4-line SPI HD mode (`CONFIG_ESP_SPI_HD_PRIV_INTERFACE_4_DATA_LINES=y`): PASS
  - Build with 2-line SPI HD mode (`CONFIG_ESP_SPI_HD_PRIV_INTERFACE_2_DATA_LINES=y`): PASS (previously failed)

  ---

  ## Checklist

  - [x] This PR does not introduce breaking changes. (Only adds a conditional compile guard)
  - [ ] All CI checks pass. (Awaiting CI)
  - [ ] Documentation is updated as needed. (No docs change required)
  - [ ] Tests are updated or added as necessary. (Build test only; no functional change)
  - [ ] Code is well-commented, especially in complex areas. (Guard is self-explanatory)
  - [ ] Git history is clean — commits are squashed to the minimum necessary.