### PR TITLE
feat(wifi): add configurable retry for TX buffer exhaustion

### DIFF
--- a/slave/main/Kconfig.projbuild
+++ b/slave/main/Kconfig.projbuild
@@ -1059,10 +1059,26 @@ menu "Example Configuration"
 		bool "Enable WiFi TX retry on failure"
 		default y
 		help
-			Enable retry mechanism for WiFi internal TX operations on STA interface.
-			When enabled, the system will retry failed TX operations up to 5 times
-			with a 1ms delay between retries. Disable this to call TX only once
-			without retry, which may be useful for debugging or specific use cases.
+			Retry transient WiFi TX buffer exhaustion on the STA interface. Holding
+			the host frame during retries also applies backpressure to the host
+			transport instead of silently dropping the Ethernet frame.
+
+	if ESP_HOSTED_WIFI_TX_RETRY_ENABLED
+
+		config ESP_HOSTED_WIFI_TX_RETRY_COUNT
+			int "Maximum WiFi TX attempts"
+			range 1 100
+			default 20
+			help
+				Total number of esp_wifi_internal_tx attempts for a frame when
+				the WiFi driver reports ESP_ERR_NO_MEM.
+
+		config ESP_HOSTED_WIFI_TX_RETRY_DELAY_MS
+			int "WiFi TX retry delay (ms)"
+			range 1 100
+			default 1
+
+	endif
 
 	config ESP_HOSTED_MEM_MONITOR
 		bool "Enable Memory Monitor Interface"

--- a/slave/main/esp_hosted_coprocessor.c
+++ b/slave/main/esp_hosted_coprocessor.c
@@ -78,7 +78,6 @@ static const char *TAG = "co-pro-main";
 #define TO_HOST_QUEUE_SIZE               10
 
 #define ETH_DATA_LEN                     1500
-#define MAX_WIFI_STA_TX_RETRY            2
 
 volatile uint8_t datapath = 0;
 volatile uint8_t station_connected = 0;
@@ -681,15 +680,35 @@ static void process_priv_pkt(uint8_t *payload, uint16_t payload_len)
 	}
 }
 
+#ifdef CONFIG_ESP_HOSTED_WIFI_TX_RETRY_ENABLED
+static int wifi_sta_tx_with_retry(uint8_t *payload, uint16_t payload_len)
+{
+	int ret = ESP_OK;
+	int attempt;
+
+	for (attempt = 0; attempt < CONFIG_ESP_HOSTED_WIFI_TX_RETRY_COUNT;
+			attempt++) {
+		ret = esp_wifi_internal_tx(WIFI_IF_STA, payload, payload_len);
+		if (ret != ESP_ERR_NO_MEM ||
+				attempt + 1 == CONFIG_ESP_HOSTED_WIFI_TX_RETRY_COUNT) {
+			break;
+		}
+#if ESP_PKT_STATS
+		pkt_stats.wifi_tx_retries++;
+#endif
+		vTaskDelay(pdMS_TO_TICKS(CONFIG_ESP_HOSTED_WIFI_TX_RETRY_DELAY_MS));
+	}
+
+	return ret;
+}
+#endif
+
 static void process_rx_pkt(interface_buffer_handle_t *buf_handle)
 {
 	struct esp_payload_header *header = NULL;
 	uint8_t *payload = NULL;
 	uint16_t payload_len = 0;
 	int ret = 0;
-#ifdef CONFIG_ESP_HOSTED_WIFI_TX_RETRY_ENABLED
-	int retry_wifi_tx = MAX_WIFI_STA_TX_RETRY;
-#endif
 
 	(void)ret;
 
@@ -704,14 +723,7 @@ static void process_rx_pkt(interface_buffer_handle_t *buf_handle)
 
 		/* Forward data to wlan driver */
 #ifdef CONFIG_ESP_HOSTED_WIFI_TX_RETRY_ENABLED
-		do {
-			ret = esp_wifi_internal_tx(WIFI_IF_STA, payload, payload_len);
-			if (ret) {
-				vTaskDelay(pdMS_TO_TICKS(1));
-			}
-
-			retry_wifi_tx--;
-		} while (ret && retry_wifi_tx);
+		ret = wifi_sta_tx_with_retry(payload, payload_len);
 #else
 		ret = esp_wifi_internal_tx(WIFI_IF_STA, payload, payload_len);
 #endif

--- a/slave/main/stats.c
+++ b/slave/main/stats.c
@@ -298,9 +298,10 @@ static void stats_timer_func(void* arg)
 	test_raw_tp_rx_len = test_raw_tp_tx_len = 0;
 #endif
 #if ESP_PKT_STATS
-	ESP_LOGI(TAG, "STA: flw_ctrl(on[%lu] off[%lu]) H2S(in[%lu] out[%lu] fail[%lu]) S2H(in[%lu] out[%lu]) Ctrl: (in[%lu] rsp[%lu] evt[%lu])",
+	ESP_LOGI(TAG, "STA: flw_ctrl(on[%lu] off[%lu]) H2S(in[%lu] out[%lu] fail[%lu] retry[%lu]) S2H(in[%lu] out[%lu]) Ctrl: (in[%lu] rsp[%lu] evt[%lu])",
 			pkt_stats.sta_flowctrl_on, pkt_stats.sta_flowctrl_off,
-			pkt_stats.hs_bus_sta_in,pkt_stats.hs_bus_sta_out, pkt_stats.hs_bus_sta_fail,
+			pkt_stats.hs_bus_sta_in, pkt_stats.hs_bus_sta_out,
+			pkt_stats.hs_bus_sta_fail, pkt_stats.wifi_tx_retries,
 			pkt_stats.sta_sh_in,pkt_stats.sta_sh_out,
 			pkt_stats.serial_rx, pkt_stats.serial_tx_total, pkt_stats.serial_tx_evt);
 	ESP_LOGI(TAG, "Lwip: in[%lu] slave_out[%lu] host_out[%lu] both_out[%lu]",

--- a/slave/main/stats.h
+++ b/slave/main/stats.h
@@ -142,6 +142,7 @@ struct pkt_stats_t {
 	uint32_t hs_bus_sta_in;
 	uint32_t hs_bus_sta_out;
 	uint32_t hs_bus_sta_fail;
+	uint32_t wifi_tx_retries;
 	uint32_t serial_rx;
 	uint32_t serial_tx_total;
 	uint32_t serial_tx_evt;


### PR DESCRIPTION
## Description

Improve Wi-Fi STA transmit reliability when `esp_wifi_internal_tx()` temporarily returns `ESP_ERR_NO_MEM`.

Previously, the co-processor used a fixed retry count and retried every transmit error. This change:

* Adds a dedicated `wifi_sta_tx_with_retry()` helper.
* Retries only when `esp_wifi_internal_tx()` returns `ESP_ERR_NO_MEM`.
* Returns other errors immediately.
* Makes the maximum number of attempts configurable through `ESP_HOSTED_WIFI_TX_RETRY_COUNT`.
* Makes the delay between attempts configurable through `ESP_HOSTED_WIFI_TX_RETRY_DELAY_MS`.
* Uses 20 attempts and a 1 ms delay by default.
* Keeps the host frame while retrying, applying backpressure instead of immediately dropping the frame.
* Adds `wifi_tx_retries` to the packet statistics output.

The retry mechanism remains controlled by `ESP_HOSTED_WIFI_TX_RETRY_ENABLED` and can be disabled to retain single-attempt behavior.

## Related

N/A

## Testing

* [ ] Built the co-processor firmware with Wi-Fi TX retry enabled.
* [ ] Built the co-processor firmware with Wi-Fi TX retry disabled.
* [ ] Verified normal Wi-Fi traffic with no TX retry errors.
* [ ] Verified that retry statistics increase when temporary Wi-Fi TX buffer exhaustion occurs.
* [ ] Verified that errors other than `ESP_ERR_NO_MEM` are returned without retrying.
* [ ] Tested sustained traffic using `[board/chip]` over `[SPI/SDIO/UART]`.

Test environment:

* Co-processor: `[ESP32 C6]`
* Host: `[K230]`
* Transport: `[SPI hd 4bit]`
* ESP-IDF version: `[6.1]`
* Traffic test: `[iperf]`

---

## Checklist

Before submitting a Pull Request, please ensure the following:

* [x] 🚨 This PR does not introduce breaking changes.
* [ ] All CI checks (GH Actions) pass.
* [x] Documentation is updated as needed.
* [ ] Tests are updated or added as necessary.
* [x] Code is well-commented, especially in complex areas.
* [x] Git history is clean — commits are squashed to the minimum necessary.
